### PR TITLE
Create file when `porquinho status` is ran.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use bigdecimal::BigDecimal;
-use clap::{Parser, ValueHint};
+use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[clap(about, version)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,5 +30,5 @@ pub enum Subcommand {
         description: String,
     },
     /// Current status for your
-    Status {},
+    Status,
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,6 +1,7 @@
 use std::{io::Write, path::Path, str};
 
 use chrono::{Datelike, Local};
+use fs_err as fs;
 
 /// Represents the filename of a Porquinho bookkeeping file
 pub struct BookkeepingFile {
@@ -26,8 +27,19 @@ impl BookkeepingFile {
 
     pub fn as_path(&self) -> &Path {
         // Safety: `current_file` must never make `self.name` be invalid UTF-8
-        let filename = str::from_utf8(&self.name).unwrap();
+        let filename = unsafe { str::from_utf8_unchecked(&self.name) };
 
         Path::new(filename)
+    }
+}
+
+pub fn create_file_if_not_existent(path: &Path) {
+    if fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .is_ok()
+    {
+        println!("Created {}", path.display());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,14 +63,14 @@ impl GlobalState {
                 amount,
                 description,
             } => (EntryType::Credit, amount, description),
-            Subcommand::Status {} => {
+            Subcommand::Status => {
                 let total = Reader::new().total_from_file(&bk_path)?;
                 println!("Status for {:?}", bk_path.file_name().unwrap());
                 println!("\tIncoming: R$ {}", total.incoming);
                 println!("\tOutgoing: R$ {}", total.outgoing);
 
-                return Ok(())
-            },
+                return Ok(());
+            }
         };
 
         let entry = Entry {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,19 +6,19 @@ mod parser;
 mod reader;
 mod writer;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use bigdecimal::BigDecimal;
 use chrono::{Datelike, Local};
 use clap::Parser;
 use dirs::Dirs;
-pub use error::{Error, Result};
+use error::{Error, Result};
 use parser::{Entry, EntryType};
 use reader::Reader;
 
 use crate::{
     cli::{Opts, Subcommand},
-    file::BookkeepingFile,
+    file::{create_file_if_not_existent, BookkeepingFile},
     writer::Writer,
 };
 
@@ -40,6 +40,8 @@ fn main() {
 struct GlobalState {
     opts: Opts,
     dirs: Dirs,
+    // Bookkeeping path
+    bk_path: PathBuf,
 }
 
 impl GlobalState {
@@ -47,48 +49,49 @@ impl GlobalState {
         let opts = Opts::parse();
         let dirs = Dirs::init()?;
 
-        Ok(Self { opts, dirs })
+        let bk_path = dirs.data().join(BookkeepingFile::current_file().as_path());
+        create_file_if_not_existent(&bk_path);
+
+        Ok(Self {
+            opts,
+            dirs,
+            bk_path,
+        })
     }
 
     pub fn run_command(self) -> Result<()> {
-        let bk_path = self.bookkeeping_file_path();
         let day = Local::today().day() as u8;
+        let Self {
+            ref bk_path,
+            opts: Opts { cmd },
+            ..
+        } = self;
 
-        let (typ, decimal, description) = match self.opts.cmd {
+        match cmd {
             Subcommand::Take {
                 amount,
-                description,
-            } => (EntryType::Debit, amount, description),
+                ref description,
+            } => {
+                let entry = Entry::new(day, EntryType::Debit, amount, description);
+                Writer::write_entry(bk_path, entry)?;
+            }
             Subcommand::Put {
                 amount,
-                description,
-            } => (EntryType::Credit, amount, description),
+                ref description,
+            } => {
+                let entry = Entry::new(day, EntryType::Credit, amount, description);
+                Writer::write_entry(bk_path, entry)?;
+            }
             Subcommand::Status => {
-                let total = Reader::new().total_from_file(&bk_path)?;
+                let total = Reader::new().total_from_file(bk_path)?;
+                // Safeyu: Always has file name because it's in format "MM-YYYY"
                 println!("Status for {:?}", bk_path.file_name().unwrap());
                 println!("\tIncoming: R$ {}", total.incoming);
                 println!("\tOutgoing: R$ {}", total.outgoing);
-
-                return Ok(());
             }
         };
 
-        let entry = Entry {
-            day,
-            typ,
-            decimal,
-            description: &description,
-        };
-
-        Writer::write_entry(&bk_path, entry)?;
-
         Ok(())
-    }
-
-    fn bookkeeping_file_path(&self) -> PathBuf {
-        self.dirs
-            .data()
-            .join(BookkeepingFile::current_file().as_path())
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,26 +33,35 @@ pub enum ParseError {
 pub struct Entry<'a> {
     pub day: u8,
     pub typ: EntryType,
-    pub decimal: BigDecimal,
+    pub amount: BigDecimal,
     // TODO: rename to account?
     // TODO: make it optional?
     pub description: &'a str,
 }
 
 impl<'a> Entry<'a> {
+    pub fn new(day: u8, typ: EntryType, amount: BigDecimal, description: &'a str) -> Self {
+        Self {
+            day,
+            typ,
+            amount,
+            description,
+        }
+    }
+
     pub fn from_str(input: &'a str) -> ParseResult<Self> {
         let (day, rest) = parse_day(input)?;
 
         let (typ, rest) = parse_entry_type(rest)?;
 
-        let (decimal, rest) = parse_decimal(rest)?;
+        let (amount, rest) = parse_decimal(rest)?;
 
         let description = parse_description(rest);
 
         Ok(Self {
             day,
             typ,
-            decimal,
+            amount,
             description,
         })
     }
@@ -133,7 +142,7 @@ mod entry_parsing {
             Entry {
                 day: 22,
                 typ: EntryType::Credit,
-                decimal: five,
+                amount: five,
                 description: "Salary"
             }
         );
@@ -143,7 +152,7 @@ mod entry_parsing {
             Entry {
                 day: 12,
                 typ: EntryType::Debit,
-                decimal: six,
+                amount: six,
                 description: "Rent"
             }
         );

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,8 +31,8 @@ impl Reader {
             let line = str::from_utf8(line)?;
             let entry = Entry::from_str(line)?;
             match entry.typ {
-                EntryType::Debit => outgoing += entry.decimal,
-                EntryType::Credit => incoming += entry.decimal,
+                EntryType::Debit => outgoing += entry.amount,
+                EntryType::Credit => incoming += entry.amount,
             }
         }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,10 +11,7 @@ pub struct Writer;
 
 impl Writer {
     pub fn write_entry(path: &Path, entry: Entry) -> Result<()> {
-        let mut file = fs::OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(path)?;
+        let mut file = fs::OpenOptions::new().append(true).open(path)?;
 
         let typ = match entry.typ {
             EntryType::Debit => "-",
@@ -26,7 +23,7 @@ impl Writer {
             "{d} {t} {a} {D}",
             d = entry.day,
             t = typ,
-            a = entry.decimal,
+            a = entry.amount,
             D = entry.description
         )?;
 


### PR DESCRIPTION
When running `porquinho` for the first time, here's the new output:

```
info: created folder "/home/joao/.config/porquinho"
info: created folder "/home/joao/.local/share/porquinho"
Created /home/joao/.local/share/porquinho/02-2022
Status for "02-2022"
	Incoming: R$ 0
	Outgoing: R$ 0
```